### PR TITLE
Delete 'vote' namespace creation

### DIFF
--- a/k9s/example-voting-app.yaml.tpl
+++ b/k9s/example-voting-app.yaml.tpl
@@ -182,14 +182,6 @@ spec:
 ---
 
 apiVersion: v1
-kind: Namespace
-metadata:
-  name: vote
-  
-  
----
-
-apiVersion: v1
 kind: Service
 metadata:
   labels:


### PR DESCRIPTION
The "vote" namespace is not required as no component is deployed in that namespace
Also, as more than one persono are going to run the shell script and this namespace is not parametrized it's going to fail when the second person tries to create an existing namespace